### PR TITLE
fix(UPS监控): 兼容 NUT 驱动上报的 ups.realpower.nominal 字段

### DIFF
--- a/PVE-Tools.sh
+++ b/PVE-Tools.sh
@@ -3084,7 +3084,7 @@ EOF
                     UPS_DATA=\$(timeout --signal=TERM 3s upsc "\$UPS_TARGET" 2>/dev/null)
                     UPS_EXIT=\$?
                     if [ "\$UPS_EXIT" -eq 0 ] && [ -n "\$UPS_DATA" ]; then
-                        FILTERED_DATA=\$(printf "%s\n" "\$UPS_DATA" | grep -E "^(device\.model|ups\.status|battery\.charge|battery\.runtime|input\.voltage|output\.voltage|ups\.load|ups\.power\.nominal|ups\.realpower|battery\.charge\.low|battery\.voltage|ups\.beeper\.status|ups\.delay\.shutdown|ups\.timer\.shutdown|ups\.delay\.start|ups\.timer\.start):" || true)
+                        FILTERED_DATA=\$(printf "%s\n" "\$UPS_DATA" | grep -E "^(device\.model|ups\.status|battery\.charge|battery\.runtime|input\.voltage|output\.voltage|ups\.load|ups\.power\.nominal|ups\.realpower\.nominal|ups\.realpower|battery\.charge\.low|battery\.voltage|ups\.beeper\.status|ups\.delay\.shutdown|ups\.timer\.shutdown|ups\.delay\.start|ups\.timer\.start):" || true)
                         if [ -n "\$FILTERED_DATA" ]; then
                             printf "%s\n" "\$FILTERED_DATA"
                             echo "UPS_TARGET: \$UPS_TARGET"
@@ -3592,7 +3592,7 @@ EOF
                 const inputVoltage = getValue('input\\.voltage');
                 const outputVoltage = getValue('output\\.voltage');
                 const loadRaw = getValue('ups\\.load');
-                const nominalPowerRaw = getValue('ups\\.power\\.nominal');
+                const nominalPowerRaw = getValue('ups\\.realpower\\.nominal') || getValue('ups\\.power\\.nominal');
                 const realPowerRaw = getValue('ups\\.realpower');
                 const batteryVoltage = getValue('battery\\.voltage');
                 const beeper = getValue('ups\\.beeper\\.status');


### PR DESCRIPTION
部分 NUT 驱动（如 APC HID）上报的是 ups.realpower.nominal（W）， 而非 ups.power.nominal（VA）。旧逻辑两处问题导致此类设备的额定/当前功率显示为 -：

1. shell grep 过滤白名单只允许 ups.realpower:，把 ups.realpower.nominal: 这行 过滤掉了，前端拿不到数据
2. JS 解析仅读取 ups.power.nominal，缺失即认为额定功率不可用，连带 nominal × load% 的当前功率估算也无法进行

修复后优先读取 ups.realpower.nominal，缺失时 fallback 到 ups.power.nominal， APC Back-UPS 等通过 usbhid-ups 接入的设备可正常显示额定功率与估算的当前功率。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了UPS监控系统对功率字段的兼容性，现支持新旧两种字段名称，确保无论NUT使用哪种格式，额定功率的计算和显示均可正常工作。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->