### PR TITLE
fix: 修复网络配置界面输出重定向问题

### DIFF
--- a/PVE-Tools.sh
+++ b/PVE-Tools.sh
@@ -8743,13 +8743,13 @@ host_network_select_from_text() {
         return 1
     fi
 
-    echo -e "${CYAN}${title}${NC}"
+    echo -e "${CYAN}${title}${NC}" >&2
     local i=1
     for item in "${items[@]}"; do
-        printf '  [%d] %s\n' "$i" "$item"
+        printf '  [%d] %s\n' "$i" "$item" >&2
         i=$((i + 1))
     done
-    echo "$UI_DIVIDER"
+    echo "$UI_DIVIDER" >&2
 
     local pick
     read -p "请选择序号 (0 返回): " pick
@@ -8809,9 +8809,9 @@ host_network_collect_family_config() {
 
     if [[ "$family" == "inet" ]]; then
         if [[ "$phase" == "update" ]]; then
-            echo "  [1] 保持当前 IPv4"
-            echo "  [2] 静态 IPv4"
-            echo "  [3] DHCPv4"
+            echo "  [1] 保持当前 IPv4" >&2
+            echo "  [2] 静态 IPv4" >&2
+            echo "  [3] DHCPv4" >&2
             read -p "请选择 IPv4 模式 [1-3]: " choice
             case "$choice" in
                 1|"") echo "keep|||"; return 0 ;;
@@ -8820,9 +8820,9 @@ host_network_collect_family_config() {
                 *) return 1 ;;
             esac
         else
-            echo "  [1] 静态 IPv4"
-            echo "  [2] DHCPv4"
-            echo "  [3] 不配置 IPv4"
+            echo "  [1] 静态 IPv4" >&2
+            echo "  [2] DHCPv4" >&2
+            echo "  [3] 不配置 IPv4" >&2
             read -p "请选择 IPv4 模式 [1-3]: " choice
             case "$choice" in
                 1) method="static" ;;
@@ -8833,11 +8833,11 @@ host_network_collect_family_config() {
         fi
     else
         if [[ "$phase" == "update" ]]; then
-            echo "  [1] 保持当前 IPv6"
-            echo "  [2] 静态 IPv6"
-            echo "  [3] DHCPv6"
-            echo "  [4] SLAAC"
-            echo "  [5] 移除 IPv6 stanza"
+            echo "  [1] 保持当前 IPv6" >&2
+            echo "  [2] 静态 IPv6" >&2
+            echo "  [3] DHCPv6" >&2
+            echo "  [4] SLAAC" >&2
+            echo "  [5] 移除 IPv6 stanza" >&2
             read -p "请选择 IPv6 模式 [1-5]: " choice
             case "$choice" in
                 1|"") echo "keep|||"; return 0 ;;
@@ -8848,10 +8848,10 @@ host_network_collect_family_config() {
                 *) return 1 ;;
             esac
         else
-            echo "  [1] 静态 IPv6"
-            echo "  [2] DHCPv6"
-            echo "  [3] SLAAC"
-            echo "  [4] 不配置 IPv6"
+            echo "  [1] 静态 IPv6" >&2
+            echo "  [2] DHCPv6" >&2
+            echo "  [3] SLAAC" >&2
+            echo "  [4] 不配置 IPv6" >&2
             read -p "请选择 IPv6 模式 [1-4]: " choice
             case "$choice" in
                 1) method="static" ;;
@@ -9520,16 +9520,16 @@ host_firewall_select_guest() {
     fi
     mapfile -t items < <(printf '%s\n' "$list_text" | awk 'NF')
     (( ${#items[@]} > 0 )) || return 1
-    echo -e "${CYAN}请选择${kind^^}：${NC}"
+    echo -e "${CYAN}请选择${kind^^}：${NC}" >&2
     local idx=1
     local item id name
     for item in "${items[@]}"; do
         id="${item%%|*}"
         name="${item#*|}"
-        printf '  [%d] %s (%s)\n' "$idx" "$id" "$name"
+        printf '  [%d] %s (%s)\n' "$idx" "$id" "$name" >&2
         idx=$((idx + 1))
     done
-    echo "$UI_DIVIDER"
+    echo "$UI_DIVIDER" >&2
     local pick
     read -p "请选择序号 (0 返回): " pick
     pick="${pick:-0}"

--- a/PVE-Tools.sh
+++ b/PVE-Tools.sh
@@ -8914,7 +8914,7 @@ host_network_collect_preserved_family_options() {
         /^[[:space:]]+/ {
             line=$0
             sub(/^[[:space:]]+/, "", line)
-            if (line ~ /^(address|gateway|netmask|broadcast|pointopoint|accept-ra|dns-nameservers|dns-search)\b/) next
+            if (line ~ /^(address|gateway|netmask|broadcast|pointopoint|accept-ra|dns-nameservers|dns-search)([[:space:]]|$)/) next
             if (line ~ /MASQUERADE/) next
             if (line ~ /net\.ipv6\.conf\.all\.forwarding/) next
             print line
@@ -8932,7 +8932,7 @@ host_network_remove_iface_family_from_candidate() {
         BEGIN { skip=0 }
         {
             if (skip) {
-                if ($0 !~ /^[[:space:]]/ && $0 ~ /^(iface|auto|allow-)/) {
+                if ($0 !~ /^[[:space:]]/ && $0 !~ /^$/) {
                     skip=0
                 } else {
                     next
@@ -8968,7 +8968,7 @@ host_network_remove_iface_from_candidate() {
         }
         {
             if (skip) {
-                if ($0 !~ /^[[:space:]]/ && $0 ~ /^(iface|auto|allow-)/) {
+                if ($0 !~ /^[[:space:]]/ && $0 !~ /^$/) {
                     skip=0
                 } else {
                     next


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **重构**
  * 交互式网络与防火墙选择菜单现在将可读菜单输出写入 stderr，stdout 仅保留机器可解析的返回值，提升与其它工具的集成兼容性。
  * 调整主机网络配置编辑的匹配与段落删除逻辑：保留选项匹配更严格以避免误匹配，段落删除终止条件改为遇到非缩进空行，减少误删配置块。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->